### PR TITLE
Chao9441/update for arcgis earth v1.10

### DIFF
--- a/src/ArcGISEarth.AutoAPI.Examples/MainWindowViewModel.cs
+++ b/src/ArcGISEarth.AutoAPI.Examples/MainWindowViewModel.cs
@@ -14,7 +14,6 @@
 using System;
 using System.ComponentModel;
 using System.Windows.Input;
-using ArcGISEarth.AutoAPI.Utils;
 using ArcGISEarth.WCFNamedPipeIPC;
 
 namespace ArcGISEarth.AutoAPI.Examples

--- a/src/ArcGISEarth.AutoAPI.Examples/MainWindowViewModel.cs
+++ b/src/ArcGISEarth.AutoAPI.Examples/MainWindowViewModel.cs
@@ -15,6 +15,7 @@ using System;
 using System.ComponentModel;
 using System.Windows.Input;
 using ArcGISEarth.AutoAPI.Utils;
+using ArcGISEarth.WCFNamedPipeIPC;
 
 namespace ArcGISEarth.AutoAPI.Examples
 {

--- a/src/ArcGISEarth.AutoAPI.Utils/EarthNamedpipeAPIUtils.cs
+++ b/src/ArcGISEarth.AutoAPI.Utils/EarthNamedpipeAPIUtils.cs
@@ -11,18 +11,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using ArcGISEarth.WCFNamedPipeIPC;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.ServiceModel;
-using System.ServiceModel.Description;
-using System.Text;
-using System.Threading.Tasks;
+using ArcGISEarth.AutoAPI.Utils;
+using Esri.ArcGISEarth.WCFNamedPipeIPC;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System;
+using System.ServiceModel;
+using System.ServiceModel.Description;
+using System.Threading.Tasks;
 
-namespace ArcGISEarth.AutoAPI.Utils
+namespace ArcGISEarth.WCFNamedPipeIPC
 {
     public class MessageStringEventArgs : EventArgs
     {
@@ -78,13 +76,13 @@ namespace ArcGISEarth.AutoAPI.Utils
             try
             {
                 JObject lyrInfoObj = new JObject();
-                if(uris == null || uris.Length == 0)
+                if (uris == null || uris.Length == 0)
                 {
                     return null;
                 }
 
                 JArray uriArray = new JArray();
-                foreach(string uri in uris)
+                foreach (string uri in uris)
                 {
                     uriArray.Add(uri);
                 }
@@ -152,7 +150,7 @@ namespace ArcGISEarth.AutoAPI.Utils
                 JObject mapPointObj = JObject.Parse(mapPointJson);
                 if (mapPointObj["spatialReference"] != null)
                 {
-                    if(mapPointObj["spatialReference"]["wkid"] != null)
+                    if (mapPointObj["spatialReference"]["wkid"] != null)
                     {
                         wkid = (int)mapPointObj["spatialReference"]["wkid"];
                     }
@@ -175,7 +173,7 @@ namespace ArcGISEarth.AutoAPI.Utils
 
         public void CloseConnect()
         {
-            if(_factory != null)
+            if (_factory != null)
             {
                 _factory.Close();
                 _factory = null;
@@ -228,7 +226,7 @@ namespace ArcGISEarth.AutoAPI.Utils
                 if (!proc.IsRunning())
                 {
                     await proc.Start((msg) => ProcessStdOutCallBack(msg, ref address));
-                    if(String.IsNullOrEmpty(address))
+                    if (String.IsNullOrEmpty(address))
                     {
                         return cFailed;
                     }
@@ -265,7 +263,7 @@ namespace ArcGISEarth.AutoAPI.Utils
 
         public string AddLayer(string json)
         {
-            if(_channel == null)
+            if (_channel == null)
             {
                 return cNeedConnect;
             }
@@ -366,7 +364,7 @@ namespace ArcGISEarth.AutoAPI.Utils
             }
             catch (Exception ex)
             {
-                if(ex is FaultException<EarthNamedpipeFault>)
+                if (ex is FaultException<EarthNamedpipeFault>)
                 {
                     return (ex as FaultException<EarthNamedpipeFault>).Message;
                 }

--- a/src/ArcGISEarth.AutoAPI.Utils/IEarthNamedpipeService.cs
+++ b/src/ArcGISEarth.AutoAPI.Utils/IEarthNamedpipeService.cs
@@ -11,15 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using System.ServiceModel;
 using System.Runtime.Serialization;
 
-namespace ArcGISEarth.WCFNamedPipeIPC
+namespace Esri.ArcGISEarth.WCFNamedPipeIPC
 {
     /// <summary>
     /// Fault contract of ArcGIS Earth Automation API.

--- a/src/ArcGISEarth.AutoAPI.Utils/ProcessUtils.cs
+++ b/src/ArcGISEarth.AutoAPI.Utils/ProcessUtils.cs
@@ -12,11 +12,7 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace ArcGISEarth.AutoAPI.Utils

--- a/src/ArcGISProToArcGISEarth/ArcGISProToArcGISEarth.csproj
+++ b/src/ArcGISProToArcGISEarth/ArcGISProToArcGISEarth.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ArcGISProToArcGISEarth</RootNamespace>
     <AssemblyName>ToArcGISEarth</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkProfile />

--- a/src/ArcGISProToArcGISEarth/ArcGISProToArcGISEarth.csproj
+++ b/src/ArcGISProToArcGISEarth/ArcGISProToArcGISEarth.csproj
@@ -10,9 +10,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ArcGISProToArcGISEarth</RootNamespace>
     <AssemblyName>ToArcGISEarth</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/ArcGISProToArcGISEarth/ToolHelper.cs
+++ b/src/ArcGISProToArcGISEarth/ToolHelper.cs
@@ -14,6 +14,7 @@
 using ArcGIS.Core.CIM;
 using ArcGIS.Desktop.Mapping;
 using ArcGISEarth.AutoAPI.Utils;
+using ArcGISEarth.WCFNamedPipeIPC;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/ArcGISProToArcGISEarth/ToolHelper.cs
+++ b/src/ArcGISProToArcGISEarth/ToolHelper.cs
@@ -13,7 +13,6 @@
 
 using ArcGIS.Core.CIM;
 using ArcGIS.Desktop.Mapping;
-using ArcGISEarth.AutoAPI.Utils;
 using ArcGISEarth.WCFNamedPipeIPC;
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
Main changes in this PR:
* Update some files of `ArcGISEarth.AutoAPI.Utils.`
~~* Update the target framework of  `ArcGISProToArcGISEarth` from v4.6.1 to v4.8 to adapt to the latest `ArcGIS Pro2.5` (`ArcGIS Pro2.5` relies on .Net Framework 4.8).~~


****
* [x] Code Review @yong7743 @bentan2013 
* [x] Manual Test  @xuew8412  @gis2all

 @xuew8412 @gis2all Please help to test `Automation API Example tool` and `ArcGISProToArcGISEarth add-in`. There are two things to note here, maybe they should be explained in the documentation:

* The latest Automation API only supports ArcGIS Earth V1.10, and is not compatible with lower versions of ArcGIS Earth (maybe lower versions of ArcGIS Earth can be used, but many unexpected errors will occur).

~~* Currently ArcGISProToArcGISEarth add-in supports ArcGISPro2.5. I'm not sure if it is compatible with the lower version. I need @xuew8412  to confirm it.  If it is not compatible, please explain in the document.~~





