### PR TITLE
remove system.drawing.common package for .net core solution and displ…

### DIFF
--- a/src/ArcGISEarth.AutoAPI.Examples/ArcGISEarth.AutoAPI.Examples.NetCore.csproj
+++ b/src/ArcGISEarth.AutoAPI.Examples/ArcGISEarth.AutoAPI.Examples.NetCore.csproj
@@ -12,7 +12,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.19" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
   </ItemGroup>
 
   <Import Project="..\ArcGISEarth.AutoAPI.Shared\ArcGISEarth.AutoAPI.Shared.projitems" Label="Shared" />

--- a/src/ArcGISEarth.AutoAPI.Examples/ArcGISEarth.AutoAPI.Examples.csproj
+++ b/src/ArcGISEarth.AutoAPI.Examples/ArcGISEarth.AutoAPI.Examples.csproj
@@ -82,6 +82,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Converter\EnumToVisibilityConverter.cs" />
+    <Compile Include="EnumFunctionTypes.cs" />
     <Compile Include="MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/src/ArcGISEarth.AutoAPI.Examples/Converter/EnumToVisibilityConverter.cs
+++ b/src/ArcGISEarth.AutoAPI.Examples/Converter/EnumToVisibilityConverter.cs
@@ -1,32 +1,44 @@
-﻿using System;
+﻿// Copyright 2020 Esri
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
-using static ArcGISEarth.AutoAPI.Examples.MainWindowViewModel;
 
 namespace ArcGISEarth.AutoAPI.Examples.Converter
 {
-    public class EnumToVisibilityConverter : IValueConverter
+    public class EnumToButtonVisibilityConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var sendButtonType = (SendButtonType)value;
+            var sendButtonType = (FunctionType)value;
             var visibility = Visibility.Visible;
             switch (sendButtonType)
             {
-                case SendButtonType.GetCamera:
-                case SendButtonType.GetWorkspace:
-                case SendButtonType.ClearWorkspace:
+                case FunctionType.GetCamera:
+                case FunctionType.GetWorkspace:
+                case FunctionType.ClearWorkspace:
+                case FunctionType.TakeSnapshot:
                     visibility = Visibility.Visible;
                     break;
-                case SendButtonType.SetCamera:                    
-                case SendButtonType.SetFlight:                    
-                case SendButtonType.AddLayer:
-                case SendButtonType.GetLayer:
-                case SendButtonType.RemoveLayer:
-                case SendButtonType.ClearLayers:
-                case SendButtonType.ImportWorkspace:
-                case SendButtonType.TakeSnapshot:
+                case FunctionType.SetCamera:                    
+                case FunctionType.SetFlight:                    
+                case FunctionType.AddLayer:
+                case FunctionType.GetLayer:
+                case FunctionType.RemoveLayer:
+                case FunctionType.ClearLayers:
+                case FunctionType.ImportWorkspace:
                     visibility = Visibility.Collapsed;
                     break;
             }
@@ -43,23 +55,57 @@ namespace ArcGISEarth.AutoAPI.Examples.Converter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            var sendButtonType = (SendButtonType)value;
+            var sendButtonType = (FunctionType)value;
             var visibility = Visibility.Collapsed;
             switch (sendButtonType)
             {
-                case SendButtonType.GetCamera:
-                case SendButtonType.GetWorkspace:
-                case SendButtonType.ClearWorkspace:
+                case FunctionType.GetCamera:
+                case FunctionType.GetWorkspace:
+                case FunctionType.ClearWorkspace:
+                case FunctionType.TakeSnapshot:
                     visibility = Visibility.Collapsed;
                     break;
-                case SendButtonType.SetCamera:
-                case SendButtonType.SetFlight:
-                case SendButtonType.AddLayer:
-                case SendButtonType.GetLayer:
-                case SendButtonType.RemoveLayer:
-                case SendButtonType.ClearLayers:
-                case SendButtonType.ImportWorkspace:
-                case SendButtonType.TakeSnapshot:
+                case FunctionType.SetCamera:
+                case FunctionType.SetFlight:
+                case FunctionType.AddLayer:
+                case FunctionType.GetLayer:
+                case FunctionType.RemoveLayer:
+                case FunctionType.ClearLayers:
+                case FunctionType.ImportWorkspace:
+                    visibility = Visibility.Visible;
+                    break;
+            }
+            return visibility;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class EnumToImageVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var sendButtonType = (FunctionType)value;
+            var visibility = Visibility.Collapsed;
+
+            switch (sendButtonType)
+            {
+                case FunctionType.GetCamera:
+                case FunctionType.GetWorkspace:
+                case FunctionType.ClearWorkspace:
+                case FunctionType.SetCamera:
+                case FunctionType.SetFlight:
+                case FunctionType.AddLayer:
+                case FunctionType.GetLayer:
+                case FunctionType.RemoveLayer:
+                case FunctionType.ClearLayers:
+                case FunctionType.ImportWorkspace:
+                    visibility = Visibility.Collapsed;
+                    break;
+                case FunctionType.TakeSnapshot:
                     visibility = Visibility.Visible;
                     break;
             }

--- a/src/ArcGISEarth.AutoAPI.Examples/Converter/EnumToVisibilityConverter.cs
+++ b/src/ArcGISEarth.AutoAPI.Examples/Converter/EnumToVisibilityConverter.cs
@@ -90,7 +90,6 @@ namespace ArcGISEarth.AutoAPI.Examples.Converter
         {
             var sendButtonType = (FunctionType)value;
             var visibility = Visibility.Collapsed;
-
             switch (sendButtonType)
             {
                 case FunctionType.GetCamera:

--- a/src/ArcGISEarth.AutoAPI.Examples/EnumFunctionTypes.cs
+++ b/src/ArcGISEarth.AutoAPI.Examples/EnumFunctionTypes.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2020 Esri
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace ArcGISEarth.AutoAPI.Examples
+{
+    internal enum FunctionType
+    {
+        // UI function type
+        GetCamera,
+        SetCamera,
+        SetFlight,
+        AddLayer,
+        GetLayer,
+        RemoveLayer,
+        ClearLayers,
+        GetWorkspace,
+        ImportWorkspace,
+        ClearWorkspace,
+        TakeSnapshot,
+        ClearInputputBox,
+        Send
+    }
+}

--- a/src/ArcGISEarth.AutoAPI.Examples/MainWindow.xaml
+++ b/src/ArcGISEarth.AutoAPI.Examples/MainWindow.xaml
@@ -8,8 +8,11 @@
         Icon="./Icons/logo.ico"
         WindowStartupLocation="CenterScreen">
     <Window.Resources>
-        <converter:EnumToVisibilityConverter x:Key="EnumToButtonVisibilityConverter"/>
+        <converter:EnumToButtonVisibilityConverter x:Key="EnumToButtonVisibilityConverter"/>
         <converter:EnumToTextBoxVisibilityConverter x:Key="EnumToTextBoxVisibilityConverter"/>
+        <converter:EnumToImageVisibilityConverter x:Key="EnumToImageVisibilityConverter"/>
+        
+        
         <FontFamily x:Key="Bold">Avenir Next LT Pro Bold</FontFamily>
         <FontFamily x:Key="DemiBold">Avenir Next LT Pro Demi</FontFamily>
         <FontFamily x:Key="Regular">Avenir Next LT Pro Regular</FontFamily>
@@ -246,7 +249,7 @@
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition Height="103"/>
-                <RowDefinition Height="*" MinHeight="810"/>
+                <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <StackPanel Grid.ColumnSpan="12" Grid.Row="0" Orientation="Vertical" Background="#FF653499" >
                 <TextBlock Text="ArcGIS Earth Automation API Sample" Foreground="White" FontFamily="{StaticResource Bold}" FontSize="24" Padding="50, 35, 0, 0"/>
@@ -369,7 +372,7 @@
                     </Grid>
 
                     <!--Textbox-->
-                    <Grid x:Name="inputTextbox" Grid.Row="2" Height="319" Visibility="{Binding SendButtontype, Converter={StaticResource EnumToTextBoxVisibilityConverter}, Mode=OneWay}">
+                    <Grid x:Name="inputTextbox" Grid.Row="2" Height="300" Visibility="{Binding SendButtontype, Converter={StaticResource EnumToTextBoxVisibilityConverter}, Mode=OneWay}">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="*"/>
                             <RowDefinition Height="40"/>
@@ -406,7 +409,8 @@
                 <Grid Grid.Row="3" Grid.Column="1">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="40"/>
-                        <RowDefinition Height="319"/>
+                        <RowDefinition Height="Auto" MinHeight="300"/>
+                        <RowDefinition Height="40"/>
                     </Grid.RowDefinitions>
 
                     <Label Grid.Row="0" x:Name="outputLabel" Content="Output" FontFamily="{StaticResource DemiBold}" FontSize="14" Margin="-10, 0, 0, 0"/>
@@ -414,7 +418,13 @@
                         <Border.Effect>
                             <DropShadowEffect Color="#FF000000" Opacity="0.1"/>
                         </Border.Effect>
-                        <TextBox Grid.Row="1" Style="{StaticResource OutputTextBox}" x:Name="outputTextBox" Text="{Binding OutputString}"/>
+                        <TextBox Style="{StaticResource OutputTextBox}" x:Name="outputTextBox" Text="{Binding OutputString}"/>
+                    </Border>
+                    <Border Grid.Row="1" CornerRadius="3" Background="White" Visibility="{Binding SendButtontype, Converter={StaticResource EnumToImageVisibilityConverter}, Mode=OneWay}">
+                        <Border.Effect>
+                            <DropShadowEffect Color="#FF000000" Opacity="0.1"/>
+                        </Border.Effect>
+                        <Image Source="{Binding OutputImage}" Stretch="Fill" HorizontalAlignment="Stretch"/>
                     </Border>
                 </Grid>
             </Grid>

--- a/src/ArcGISEarth.AutoAPI.Examples/MainWindowViewModel.cs
+++ b/src/ArcGISEarth.AutoAPI.Examples/MainWindowViewModel.cs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using ArcGISEarth.AutoAPI.Examples.Converter;
 using ArcGISEarth.AutoAPI.Utils;
 using Newtonsoft.Json;
 using System;
@@ -366,9 +365,6 @@ namespace ArcGISEarth.AutoAPI.Examples
                 case FunctionType.ClearWorkspace:
                     outputStr = await helper.ClearWorkspace();
                     break;
-                //case FunctionType.TakeSnapshot:
-                //    outputStr = await helper.TakeSnapshot(inputStr);
-                //    break;
             }
 
             return outputStr;
@@ -381,7 +377,6 @@ namespace ArcGISEarth.AutoAPI.Examples
             {
                 outputImg = await helper.TakeSnapshot();
             }
-
             return outputImg;
         }
     }

--- a/src/ArcGISEarth.AutoAPI.Examples/MainWindowViewModel.cs
+++ b/src/ArcGISEarth.AutoAPI.Examples/MainWindowViewModel.cs
@@ -11,33 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using ArcGISEarth.AutoAPI.Examples.Converter;
 using ArcGISEarth.AutoAPI.Utils;
 using Newtonsoft.Json;
 using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using System.Windows.Media;
 
 namespace ArcGISEarth.AutoAPI.Examples
 {
-    internal enum FunctionType
-    {
-        // UI function type
-        GetCamera,
-        SetCamera,
-        SetFlight,
-        AddLayer,
-        GetLayer,
-        RemoveLayer,
-        ClearLayers,
-        GetWorkspace,
-        ImportWorkspace,
-        ClearWorkspace,
-        TakeSnapshot,
-        ClearInputputBox,
-        Send
-    }
-
     internal class FunctionTypeCommand : ICommand
     {
         // Implement ICommand
@@ -126,7 +110,22 @@ namespace ArcGISEarth.AutoAPI.Examples
                 }
             }
         }
-        
+
+        private ImageSource _outputImage;
+
+        public ImageSource OutputImage
+        {
+            get { return _outputImage; }
+            set
+            {
+                if (_outputImage != value)
+                {
+                    _outputImage = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(OutputImage)));
+                }
+            }
+        }
+
         public ICommand GetCameraCommand { get; private set; }
 
         public ICommand SetCameraCommand { get; private set; }
@@ -176,23 +175,8 @@ namespace ArcGISEarth.AutoAPI.Examples
             SendButtonCommand = new FunctionTypeCommand(e => ExecuteFuction(FunctionType.Send));
         }
 
-        public enum SendButtonType
-        {
-            GetCamera,
-            SetCamera,
-            SetFlight,
-            AddLayer,
-            GetLayer,
-            RemoveLayer,
-            ClearLayers,
-            GetWorkspace,
-            ImportWorkspace,
-            ClearWorkspace,
-            TakeSnapshot
-        }
-
-        private SendButtonType _sendButtonType;
-        public SendButtonType SendButtontype 
+        private FunctionType _sendButtonType;
+        public FunctionType SendButtontype 
         {
             get { return _sendButtonType; }
             set 
@@ -243,14 +227,14 @@ namespace ArcGISEarth.AutoAPI.Examples
                 case FunctionType.GetCamera:
                     {
                         InputString = "";
-                        SendButtontype = SendButtonType.GetCamera;
+                        SendButtontype = FunctionType.GetCamera;
                         OutputString = "";
                         break;
                     }
                 case FunctionType.SetCamera:
                     {
                         InputString = "";
-                        SendButtontype = SendButtonType.SetCamera;
+                        SendButtontype = FunctionType.SetCamera;
                         InputPlaceholderString = "Example:\n\n" + PrettyJson(CAMERA_EXAMPLE);
                         OutputString = "";
                         break;
@@ -258,7 +242,7 @@ namespace ArcGISEarth.AutoAPI.Examples
                 case FunctionType.SetFlight:
                     {
                         InputString = "";
-                        SendButtontype = SendButtonType.SetFlight;
+                        SendButtontype = FunctionType.SetFlight;
                         InputPlaceholderString = "Example:\n\n" + PrettyJson(FLIGHT_EXAMPLE);
                         OutputString = "";
                         break;
@@ -266,7 +250,7 @@ namespace ArcGISEarth.AutoAPI.Examples
                 case FunctionType.AddLayer:
                     {
                         InputString = "";
-                        SendButtontype = SendButtonType.AddLayer;
+                        SendButtontype = FunctionType.AddLayer;
                         InputPlaceholderString = "Example:\n\n" + PrettyJson(ADDLAYER_EXAMPLE);
                         OutputString = "";
                         break;
@@ -274,7 +258,7 @@ namespace ArcGISEarth.AutoAPI.Examples
                 case FunctionType.GetLayer:
                     {
                         InputString = "";
-                        SendButtontype = SendButtonType.GetLayer;
+                        SendButtontype = FunctionType.GetLayer;
                         InputPlaceholderString = "Example:\n\n" + GETLAYER_EXAMPLE;
                         OutputString = "";
                         break;
@@ -282,7 +266,7 @@ namespace ArcGISEarth.AutoAPI.Examples
                 case FunctionType.RemoveLayer:
                     {
                         InputString = "";
-                        SendButtontype = SendButtonType.RemoveLayer;
+                        SendButtontype = FunctionType.RemoveLayer;
                         InputPlaceholderString = "Example:\n\n" + REMOVELAYER_EXAMPLE;
                         OutputString = "";
                         break;
@@ -290,7 +274,7 @@ namespace ArcGISEarth.AutoAPI.Examples
                 case FunctionType.ClearLayers:
                     {
                         InputString = "";
-                        SendButtontype = SendButtonType.ClearLayers;
+                        SendButtontype = FunctionType.ClearLayers;
                         InputPlaceholderString = "Example:\n\n" + REMOVELAYERS_EXAMPLE;
                         OutputString = "";
                         break;
@@ -298,14 +282,14 @@ namespace ArcGISEarth.AutoAPI.Examples
                 case FunctionType.GetWorkspace:
                     {
                         InputString = "";
-                        SendButtontype = SendButtonType.GetWorkspace;
+                        SendButtontype = FunctionType.GetWorkspace;
                         OutputString = "";
                         break;
                     }
                 case FunctionType.ImportWorkspace:
                     {
                         InputString = "";
-                        SendButtontype = SendButtonType.ImportWorkspace;
+                        SendButtontype = FunctionType.ImportWorkspace;
                         InputPlaceholderString = "Example:\n\n" + PrettyJson(IMPORTWORKSPACE_EXAMPLE);
                         OutputString = "";
                         break;
@@ -313,15 +297,16 @@ namespace ArcGISEarth.AutoAPI.Examples
                 case FunctionType.ClearWorkspace:
                     {
                         InputString = "";
-                        SendButtontype = SendButtonType.ClearWorkspace;
+                        SendButtontype = FunctionType.ClearWorkspace;
                         OutputString = "";
                         break;
                     }
                 case FunctionType.TakeSnapshot:
                     {
-                        SendButtontype = SendButtonType.TakeSnapshot;
+                        SendButtontype = FunctionType.TakeSnapshot;
                         InputPlaceholderString = "Example:\n\n" + TAKESNAPSHOT_EXAMPLE;
                         OutputString = "";
+                        OutputImage = null;
                         break;
                     }
                 case FunctionType.ClearInputputBox:
@@ -332,53 +317,72 @@ namespace ArcGISEarth.AutoAPI.Examples
                 case FunctionType.Send:
                     {
                         OutputString = "Waiting response...";
-                        string outputString = await SendMessage(_helper, SendButtontype, InputString);
-                        OutputString = PrettyJson(outputString);
+                        if (SendButtontype != FunctionType.TakeSnapshot)
+                        {
+                            string outputString = await SendMessage(_helper, SendButtontype, InputString);
+                            OutputString = PrettyJson(outputString);
+                        }
+                        else
+                        {
+                            OutputImage = await TakeSnapshotSend(_helper, SendButtontype);
+                        }
                         break;
                     }
             }            
         }
 
-        private async Task<string> SendMessage(AutomationAPIHelper helper, SendButtonType sendType, string inputStr)
+        private async Task<string> SendMessage(AutomationAPIHelper helper, FunctionType sendType, string inputStr)
         {
             string outputStr = null;
             switch (sendType)
             {
-                case SendButtonType.GetCamera:
+                case FunctionType.GetCamera:
                     outputStr = await helper.GetCamera();
                     break;
-                case SendButtonType.SetCamera:
+                case FunctionType.SetCamera:
                     outputStr = await helper.SetCamera(inputStr);
                     break;
-                case SendButtonType.SetFlight:
+                case FunctionType.SetFlight:
                     outputStr = await helper.SetFlight(inputStr);
                     break;
-                case SendButtonType.AddLayer:
+                case FunctionType.AddLayer:
                     outputStr = await helper.AddLayer(inputStr);
                     break;
-                case SendButtonType.GetLayer:
+                case FunctionType.GetLayer:
                     outputStr = await helper.GetLayer(inputStr);
                     break;
-                case SendButtonType.RemoveLayer:
+                case FunctionType.RemoveLayer:
                     outputStr = await helper.RemoveLayer(inputStr);
                     break;
-                case SendButtonType.ClearLayers:
+                case FunctionType.ClearLayers:
                     outputStr = await helper.ClearLayers(inputStr);
                     break;
-                case SendButtonType.GetWorkspace:
+                case FunctionType.GetWorkspace:
                     outputStr = await helper.GetWorkspace();
                     break;
-                case SendButtonType.ImportWorkspace:
+                case FunctionType.ImportWorkspace:
                     outputStr = await helper.ImportWorkspace(inputStr);
                     break;
-                case SendButtonType.ClearWorkspace:
+                case FunctionType.ClearWorkspace:
                     outputStr = await helper.ClearWorkspace();
                     break;
-                case SendButtonType.TakeSnapshot:
-                    outputStr = await helper.TakeSnapshot(inputStr);
-                    break;
+                //case FunctionType.TakeSnapshot:
+                //    outputStr = await helper.TakeSnapshot(inputStr);
+                //    break;
             }
+
             return outputStr;
+        }
+
+        private async Task<ImageSource> TakeSnapshotSend(AutomationAPIHelper helper, FunctionType sendType)
+        {
+            ImageSource outputImg = null;
+            if (sendType == FunctionType.TakeSnapshot)
+            {
+                outputImg = await helper.TakeSnapshot();
+            }
+
+            return outputImg;
         }
     }
 }

--- a/src/ArcGISEarth.AutoAPI.Shared/AutomationAPIHelper.cs
+++ b/src/ArcGISEarth.AutoAPI.Shared/AutomationAPIHelper.cs
@@ -200,49 +200,6 @@ namespace ArcGISEarth.AutoAPI.Utils
             }
         }
 
-        //public async Task<string> TakeSnapshot(string imagePath)
-        //{
-        //    try
-        //    {
-        //        string snapshotRequestUrl = $"{APIBaseUrl}/{SnapshotControllerName}";
-        //        var uri = new Uri(imagePath);
-        //        if (uri.IsAbsoluteUri && uri.IsFile)
-        //        {
-        //            var ext = Path.GetExtension(imagePath);
-        //            if (string.IsNullOrEmpty(ext))
-        //            {
-        //                imagePath += ".jpg";
-        //            }
-        //            ext = Path.GetExtension(imagePath).ToLower();
-        //            if (ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".tif" || ext == ".tiff")
-        //            {
-        //                HttpClient httpClient = new HttpClient();
-        //                HttpResponseMessage responseMessage = await httpClient.GetAsync(snapshotRequestUrl);
-        //                HttpContent content = responseMessage.Content;
-        //                using (Stream stream = await content.ReadAsStreamAsync())
-        //                {
-        //                    var image = Image.FromStream(stream);
-        //                    image.Save(imagePath);
-        //                }
-
-        //                return "Take snapshot successfully: " + imagePath + ".";
-        //            }
-        //            else
-        //            {
-        //                return "Take snapshot failed, please try to input a correct image format.";
-        //            }
-        //        }
-        //        else
-        //        {
-        //            return "Take snapshot failed, please input a correct file path.";
-        //        }
-        //    }
-        //    catch (Exception ex)
-        //    {
-        //        return ex.Message;
-        //    }
-        //}
-
         public async Task<ImageSource> TakeSnapshot()
         {
             try
@@ -251,7 +208,6 @@ namespace ArcGISEarth.AutoAPI.Utils
                 HttpClient httpClient = new HttpClient();
                 HttpResponseMessage responseMessage = await httpClient.GetAsync(snapshotRequestUrl);
                 HttpContent content = responseMessage.Content;
-
                 BitmapImage biImg = new BitmapImage();
                 using (Stream stream = await content.ReadAsStreamAsync())
                 {
@@ -259,9 +215,7 @@ namespace ArcGISEarth.AutoAPI.Utils
                     biImg.StreamSource = stream;
                     biImg.EndInit();
                 }
-
                 ImageSource imgSrc = biImg as ImageSource;
-
                 return imgSrc;
             }
             catch
@@ -307,7 +261,6 @@ namespace ArcGISEarth.AutoAPI.Utils
                     }
                     catch { }
                 }
-
                 return myFolder;
             }
         }

--- a/src/ArcGISEarth.AutoAPI.Shared/AutomationAPIHelper.cs
+++ b/src/ArcGISEarth.AutoAPI.Shared/AutomationAPIHelper.cs
@@ -208,15 +208,14 @@ namespace ArcGISEarth.AutoAPI.Utils
                 HttpClient httpClient = new HttpClient();
                 HttpResponseMessage responseMessage = await httpClient.GetAsync(snapshotRequestUrl);
                 HttpContent content = responseMessage.Content;
-                BitmapImage biImg = new BitmapImage();
+                BitmapImage bmpImg = new BitmapImage();
                 using (Stream stream = await content.ReadAsStreamAsync())
                 {
-                    biImg.BeginInit();
-                    biImg.StreamSource = stream;
-                    biImg.EndInit();
+                    bmpImg.BeginInit();
+                    bmpImg.StreamSource = stream;
+                    bmpImg.EndInit();
                 }
-                ImageSource imgSrc = biImg as ImageSource;
-                return imgSrc;
+                return bmpImg;
             }
             catch
             {

--- a/src/ArcGISEarth.AutoAPI.Shared/AutomationAPIHelper.cs
+++ b/src/ArcGISEarth.AutoAPI.Shared/AutomationAPIHelper.cs
@@ -13,11 +13,12 @@
 
 using Newtonsoft.Json.Linq;
 using System;
-using System.Drawing;
 using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
 
 namespace ArcGISEarth.AutoAPI.Utils
 {
@@ -199,45 +200,73 @@ namespace ArcGISEarth.AutoAPI.Utils
             }
         }
 
-        public async Task<string> TakeSnapshot(string imagePath)
+        //public async Task<string> TakeSnapshot(string imagePath)
+        //{
+        //    try
+        //    {
+        //        string snapshotRequestUrl = $"{APIBaseUrl}/{SnapshotControllerName}";
+        //        var uri = new Uri(imagePath);
+        //        if (uri.IsAbsoluteUri && uri.IsFile)
+        //        {
+        //            var ext = Path.GetExtension(imagePath);
+        //            if (string.IsNullOrEmpty(ext))
+        //            {
+        //                imagePath += ".jpg";
+        //            }
+        //            ext = Path.GetExtension(imagePath).ToLower();
+        //            if (ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".tif" || ext == ".tiff")
+        //            {
+        //                HttpClient httpClient = new HttpClient();
+        //                HttpResponseMessage responseMessage = await httpClient.GetAsync(snapshotRequestUrl);
+        //                HttpContent content = responseMessage.Content;
+        //                using (Stream stream = await content.ReadAsStreamAsync())
+        //                {
+        //                    var image = Image.FromStream(stream);
+        //                    image.Save(imagePath);
+        //                }
+
+        //                return "Take snapshot successfully: " + imagePath + ".";
+        //            }
+        //            else
+        //            {
+        //                return "Take snapshot failed, please try to input a correct image format.";
+        //            }
+        //        }
+        //        else
+        //        {
+        //            return "Take snapshot failed, please input a correct file path.";
+        //        }
+        //    }
+        //    catch (Exception ex)
+        //    {
+        //        return ex.Message;
+        //    }
+        //}
+
+        public async Task<ImageSource> TakeSnapshot()
         {
             try
             {
                 string snapshotRequestUrl = $"{APIBaseUrl}/{SnapshotControllerName}";
-                var uri = new Uri(imagePath);
-                if (uri.IsAbsoluteUri && uri.IsFile)
+                HttpClient httpClient = new HttpClient();
+                HttpResponseMessage responseMessage = await httpClient.GetAsync(snapshotRequestUrl);
+                HttpContent content = responseMessage.Content;
+
+                BitmapImage biImg = new BitmapImage();
+                using (Stream stream = await content.ReadAsStreamAsync())
                 {
-                    var ext = Path.GetExtension(imagePath);
-                    if (string.IsNullOrEmpty(ext))
-                    {
-                        imagePath += ".jpg";
-                    }
-                    ext = Path.GetExtension(imagePath).ToLower();
-                    if (ext == ".jpg" || ext == ".jpeg" || ext == ".png" || ext == ".tif" || ext == ".tiff")
-                    {
-                        HttpClient httpClient = new HttpClient();
-                        HttpResponseMessage responseMessage = await httpClient.GetAsync(snapshotRequestUrl);
-                        HttpContent content = responseMessage.Content;
-                        using (Stream stream = await content.ReadAsStreamAsync())
-                        {
-                            var image = Image.FromStream(stream);
-                            image.Save(imagePath);
-                        }
-                        return "Take snapshot successfully: " + imagePath + ".";
-                    }
-                    else
-                    {
-                        return "Take snapshot failed, please try to input a correct image format.";
-                    }
+                    biImg.BeginInit();
+                    biImg.StreamSource = stream;
+                    biImg.EndInit();
                 }
-                else
-                {
-                    return "Take snapshot failed, please input a correct file path.";
-                }
+
+                ImageSource imgSrc = biImg as ImageSource;
+
+                return imgSrc;
             }
-            catch (Exception ex)
+            catch
             {
-                return ex.Message;
+                return null;
             }
         }
 


### PR DESCRIPTION
…ay snapshot in the UI directly.

This PR enhanced:
1. removed system.drawing.common package for the .net core solution
2. displayed snapshot in the UI directly, rather than saved in the local drive
3. Adding Copyright for the converter class
4. Extract the Enum as a class

Review and Test:
- [x] Code Review @yong7743 
- [x] Code Review and Testing @gis2all 